### PR TITLE
Drop support for old KDE applnk dirs

### DIFF
--- a/configure.h.in
+++ b/configure.h.in
@@ -109,10 +109,10 @@
 #define GNOME_APPS_PATH		"~/.gnome2/vfolders/applications/:$GNOMEDIR/share/applications:/usr/share/applications:/usr/local/share/applications"
 #define GNOME_ICONS_PATH	"~/.icons/gnome/48x48/apps/:$XDG_DATA_DIRS/icons/gnome/48x48/apps/:$GNOMEDIR/share/pixmaps:/usr/share/pixmaps:/usr/share/icons:/usr/share/icons/hicolor/48x48/apps:/usr/share/icons/hicolor/32x32/apps:/usr/share/icons/gnome/48x48/apps"
 #define GNOME_CACHE_FILE	AFTER_NONCF "/GNOMECategories"
-#define KDE_APPS_PATH		"$KDEDIR/share/applnk:$KDEDIR/share/applications:/usr/share/applnk:/usr/share/applications"
+#define KDE_APPS_PATH		"$KDEDIR/share/applications:/usr/share/applications"
 #define KDE_ICONS_PATH		"~/.icons/kde/48x48/apps/:$XDG_DATA_DIRS/icons/kde/48x48/apps/:$KDEDIR/share/icons/default.kde/48x48/apps:$KDEDIR/share/icons/hicolor/48x48/apps:$KDEDIR/share/icons/locolor/48x48/apps:/usr/share/pixmaps"
 #define KDE_CACHE_FILE		AFTER_NONCF "/KDECategories"
-#define OTHER_APPS_PATH     "/etc/X11/applnk:/usr/share/applications:/usr/local/share/applications"
+#define OTHER_APPS_PATH     "/usr/share/applications:/usr/local/share/applications"
 #define OTHER_ICONS_PATH    "/usr/share/pixmaps:/usr/local/share/pixmaps:/usr/share/icons:/usr/share/icons/hicolor/48x48/apps:/usr/share/icons/hicolor/32x32/apps"
 #define OTHER_CACHE_FILE	AFTER_NONCF "/OtherCategories"
 


### PR DESCRIPTION
applnk was the old pre-KDE 3 location for .kdelnk files. It has been long deprecated in favour of XDG locations for desktop files, so the support for these directories can be safely removed.