### PR TITLE
Makefile.in: drop 'l' from 'ar' (binutils-2.36+ support)

### DIFF
--- a/autoconf/Makefile.defines.in
+++ b/autoconf/Makefile.defines.in
@@ -9,7 +9,7 @@ CCFLAGS         = @CFLAGS@
 EXTRA_DEFINES	= 
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@

--- a/libAfterBase/Makefile.in
+++ b/libAfterBase/Makefile.in
@@ -58,7 +58,7 @@ CCFLAGS         = @CFLAGS@
 EXTRA_DEFINES	= @DEFINE_XLOCALE@
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@

--- a/libAfterImage/Makefile.in
+++ b/libAfterImage/Makefile.in
@@ -76,7 +76,7 @@ CCFLAGS         = @CFLAGS@  @MMX_CFLAGS@
 EXTRA_DEFINES	= @DEFINE_XLOCALE@
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@

--- a/libAfterImage/aftershow/Makefile.in
+++ b/libAfterImage/aftershow/Makefile.in
@@ -11,7 +11,7 @@ CCFLAGS         = @CFLAGS@
 EXTRA_DEFINES	= @DEFINE_XLOCALE@
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@

--- a/libAfterImage/apps/Makefile.in
+++ b/libAfterImage/apps/Makefile.in
@@ -8,7 +8,7 @@ CCFLAGS         = @CFLAGS@
 EXTRA_DEFINES	= @DEFINE_XLOCALE@
 
 RANLIB		= @RANLIB@
-AR		= ar clq
+AR		= ar cq
 CP		= @CP@
 MV		= @MV@
 RM		= @RM@


### PR DESCRIPTION
Before the change build failed as:

    $ make
    ...
    ar clq libAfterBase.a ashash.o aslist.o asvector.o audit.o fs.o layout.o mystring.o os.o output.o parse.o regexp.o safemalloc.o selfdiag.o sleep.o socket.o timer.o trace.o xml.o xprop.o xwrap.o
    ar: libdeps specified more than once

It used to work until binutils-2.36 because 'l' option was silently
ignored on binutils-2.35. On 2.36 'l' became 'libdeps' flag with
required option:

   https://sourceware.org/git/?p=binutils-gdb.git;a=commitdiff;h=f3016d6ce178b76002edde12c30ebe7f608a8e21

Applied change as:

    $ sed -i 's/ar clq/ar cq/g' */*.in */*/*.in

Closes: https://github.com/afterstep/afterstep/issues/2
Closes: https://github.com/afterstep/afterstep/issues/3